### PR TITLE
Added in-memory filesystem support using the spf13/afero filesystem abstraction library

### DIFF
--- a/indexer.go
+++ b/indexer.go
@@ -1,15 +1,12 @@
-
 package fulltext
 
 import (
-	"fmt"
-	"os"
-	"io"
-	"io/ioutil"
-	"syscall"
 	"bytes"
 	"encoding/gob"
+	"fmt"
 	"github.com/jbarham/go-cdb"
+	"github.com/spf13/afero"
+	"io"
 )
 
 // Size of header block to prepend - make it 4k to align disk reads
@@ -17,39 +14,64 @@ const HEADER_SIZE = 4096
 
 // Produces a set of cdb files from a series of AddDoc() calls
 type Indexer struct {
-	docTxtFile *os.File
-	wordTxtFile *os.File
-	docCdbFile *os.File
-	wordCdbFile *os.File
-	wordMap map[string]map[string]int // map of [word][docId]count
-    WordSplit WordSplitter
-    WordClean WordCleaner
+	filesystem  afero.Fs
+	docTxtFile  afero.File
+	wordTxtFile afero.File
+	docCdbFile  afero.File
+	wordCdbFile afero.File
+	wordMap     map[string]map[string]int // map of [word][docId]count
+	WordSplit   WordSplitter
+	WordClean   WordCleaner
 }
 
 // Contents of a single document to be indexed
 type IndexDoc struct {
-	Id []byte // the id, this is usually the path to the document
+	Id         []byte // the id, this is usually the path to the document
 	IndexValue []byte // index this data
 	StoreValue []byte // store this data
 }
 
-// Creates a new indexer, using the given temp dir while building
-// the index.
-func NewIndexer(tempDir string) (*Indexer, error) {
+// NewIndexer creates a new indexer.
+func NewIndexer() (*Indexer, error) {
+
+	var indexFs afero.Fs = &afero.MemMapFs{}
+
 	idx := &Indexer{}
-	var err error
-	idx.docTxtFile, err = ioutil.TempFile(tempDir, "doctmp"); if err != nil { return nil, err }
-	idx.wordTxtFile, err = ioutil.TempFile(tempDir, "wordtmp"); if err != nil { return nil, err }
-	idx.docCdbFile, err = ioutil.TempFile(tempDir, "doccdb"); if err != nil { return nil, err }
-	idx.wordCdbFile, err = ioutil.TempFile(tempDir, "wordcdb"); if err != nil { return nil, err }
+	idx.filesystem = indexFs
+
+	docTxtFile, err := indexFs.Create("doctmp")
+	if err != nil {
+		return nil, err
+	}
+
+	wordTxtFile, err := indexFs.Create("wordtmp")
+	if err != nil {
+		return nil, err
+	}
+
+	docCdbFile, err := indexFs.Create("doccdb")
+	if err != nil {
+		return nil, err
+	}
+
+	wordCdbFile, err := indexFs.Create("wordcdb")
+	if err != nil {
+		return nil, err
+	}
+
+	idx.docTxtFile = docTxtFile
+	idx.wordTxtFile = wordTxtFile
+	idx.docCdbFile = docCdbFile
+	idx.wordCdbFile = wordCdbFile
 	idx.wordMap = make(map[string]map[string]int)
-    idx.WordSplit = Wordize
-    idx.WordClean = IndexizeWord
+	idx.WordSplit = Wordize
+	idx.WordClean = IndexizeWord
+
 	return idx, nil
 }
 
 // Add a document to the index - writes to temporary files and stores some data in memory while building the index.
-func (idx *Indexer)AddDoc(idoc IndexDoc) error {
+func (idx *Indexer) AddDoc(idoc IndexDoc) error {
 	// add to docs
 	docId := string(idoc.Id)
 	writeTextLine(idx.docTxtFile, []byte(docId), idoc.StoreValue)
@@ -57,7 +79,9 @@ func (idx *Indexer)AddDoc(idoc IndexDoc) error {
 	for _, word := range words {
 		word = idx.WordClean(word)
 		// ensure nested map exists
-		if idx.wordMap[word] == nil { idx.wordMap[word] = make(map[string]int) }
+		if idx.wordMap[word] == nil {
+			idx.wordMap[word] = make(map[string]int)
+		}
 		// increment count by one for this combination
 		c := idx.wordMap[word][docId] + 1
 		idx.wordMap[word][docId] = c
@@ -67,7 +91,7 @@ func (idx *Indexer)AddDoc(idoc IndexDoc) error {
 
 // Builds a final single index file, which consists of some simple header info,
 // followed by the cdb binary files that comprise the full index.
-func (idx *Indexer)FinalizeAndWrite(w io.Writer) error {
+func (idx *Indexer) FinalizeAndWrite(w io.Writer) error {
 
 	var buf bytes.Buffer
 
@@ -84,21 +108,43 @@ func (idx *Indexer)FinalizeAndWrite(w io.Writer) error {
 	idx.docTxtFile.Write([]byte("\n"))
 	idx.wordTxtFile.Write([]byte("\n"))
 
-	_, err = idx.docTxtFile.Seek(0, 0); if err != nil { return err }
-	_, err = idx.wordTxtFile.Seek(0, 0); if err != nil { return err }
+	_, err = idx.docTxtFile.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+	_, err = idx.wordTxtFile.Seek(0, 0)
+	if err != nil {
+		return err
+	}
 
 	// make cdb files
-	err = cdb.Make(idx.docCdbFile, idx.docTxtFile); if err != nil { return err }
-	err = cdb.Make(idx.wordCdbFile, idx.wordTxtFile); if err != nil { return err }
+	err = cdb.Make(idx.docCdbFile, idx.docTxtFile)
+	if err != nil {
+		return err
+	}
+	err = cdb.Make(idx.wordCdbFile, idx.wordTxtFile)
+	if err != nil {
+		return err
+	}
 
 	// make sure the contents are all settled
-	idx.docCdbFile.Sync()
-	idx.wordCdbFile.Sync()
-	_, err = idx.docCdbFile.Seek(0, 0); if err != nil { return err }
-	_, err = idx.wordCdbFile.Seek(0, 0); if err != nil { return err }
+	_, err = idx.docCdbFile.Seek(0, 0)
+	if err != nil {
+		return err
+	}
+	_, err = idx.wordCdbFile.Seek(0, 0)
+	if err != nil {
+		return err
+	}
 
-	docStat, err := idx.docCdbFile.Stat(); if err != nil { return err }
-	wordStat, err := idx.wordCdbFile.Stat(); if err != nil { return err }
+	docStat, err := idx.docCdbFile.Stat()
+	if err != nil {
+		return err
+	}
+	wordStat, err := idx.wordCdbFile.Stat()
+	if err != nil {
+		return err
+	}
 
 	// now package it all up
 	buf.Reset()
@@ -107,34 +153,38 @@ func (idx *Indexer)FinalizeAndWrite(w io.Writer) error {
 	enc.Encode(bhead)
 
 	// extend buffer to be HEADER_SIZE len
-	bpadsize := HEADER_SIZE-buf.Len()
+	bpadsize := HEADER_SIZE - buf.Len()
 	buf.Write(make([]byte, bpadsize, bpadsize))
 	b := buf.Bytes()
 
-	_, err = w.Write(b); if err != nil { return err }
+	_, err = w.Write(b)
+	if err != nil {
+		return err
+	}
 
-	_, err = io.Copy(w, idx.docCdbFile); if err != nil { return err }
-	_, err = io.Copy(w, idx.wordCdbFile); if err != nil { return err }
+	_, err = io.Copy(w, idx.docCdbFile)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(w, idx.wordCdbFile)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
 
-// Dump some human readable status information
-func (idx *Indexer)DumpStatus(w io.Writer) {
-	fmt.Fprintf(w, "files used:\n\t%s\n\t%s\n\t%s\n\t%s\n", idx.docTxtFile.Name(), idx.wordTxtFile.Name(), idx.docCdbFile.Name(), idx.wordCdbFile.Name())
-	// fmt.Fprintf(w, "wordMap: %+v\n", idx.wordMap)
-}
-
 // close and remove all resources
-func (idx *Indexer)Close() {
-	syscall.Unlink(idx.docTxtFile.Name()); idx.docTxtFile.Close()
-	syscall.Unlink(idx.wordTxtFile.Name()); idx.wordTxtFile.Close()
-	syscall.Unlink(idx.docCdbFile.Name()); idx.docCdbFile.Close()
-	syscall.Unlink(idx.wordCdbFile.Name()); idx.wordCdbFile.Close()
+func (idx *Indexer) Close() {
+	idx.docTxtFile.Close()
+	idx.wordTxtFile.Close()
+	idx.docCdbFile.Close()
+	idx.wordCdbFile.Close()
 	idx.wordMap = nil
 }
 
 // Write a single line of data in cdb's text format
 func writeTextLine(w io.Writer, key []byte, data []byte) (err error) {
-	_, err = fmt.Fprintf(w, "+%d,%d:%s->%s\n", len(key), len(data), key, data); return
+	_, err = fmt.Fprintf(w, "+%d,%d:%s->%s\n", len(key), len(data), key, data)
+	return
 }

--- a/indexer_test.go
+++ b/indexer_test.go
@@ -1,41 +1,52 @@
-
 package fulltext
 
 import (
-	"os"
 	"fmt"
+	"github.com/spf13/afero"
 	"io/ioutil"
-	"testing"
+	"os"
 	"path/filepath"
 	re "regexp"
+	"testing"
 )
 
 func TestIndexer(t *testing.T) {
 	fmt.Printf("TestIndexer\n")
 
-	idx, err := NewIndexer(""); if err != nil { panic(err) }
+	idx, err := NewIndexer()
+	if err != nil {
+		panic(err)
+	}
 
-	idx.AddDoc(IndexDoc{Id:[]byte(`blah1`),StoreValue:[]byte(`store this`),IndexValue:[]byte(`test of the emergency broadcast system`)})
-	idx.AddDoc(IndexDoc{Id:[]byte(`blah2`),StoreValue:[]byte(`store this stuff too, yeah store it`),IndexValue:[]byte(`every good boy does fine`)})
-	idx.AddDoc(IndexDoc{Id:[]byte(`blah3`),StoreValue:[]byte(`more storage here`),IndexValue:[]byte(`a taco in the hand is worth two in the truck`)})
+	idx.AddDoc(IndexDoc{Id: []byte(`blah1`), StoreValue: []byte(`store this`), IndexValue: []byte(`test of the emergency broadcast system`)})
+	idx.AddDoc(IndexDoc{Id: []byte(`blah2`), StoreValue: []byte(`store this stuff too, yeah store it`), IndexValue: []byte(`every good boy does fine`)})
+	idx.AddDoc(IndexDoc{Id: []byte(`blah3`), StoreValue: []byte(`more storage here`), IndexValue: []byte(`a taco in the hand is worth two in the truck`)})
 
-	idx.DumpStatus(os.Stdout)
+	var indexFs afero.Fs = &afero.MemMapFs{}
 
-	f, err := ioutil.TempFile("", "idxout"); if err != nil { panic(err) }
-	err = idx.FinalizeAndWrite(f); if err != nil { panic(err) }
+	f, err := indexFs.Create("idxout")
+	if err != nil {
+		panic(err)
+	}
+	err = idx.FinalizeAndWrite(f)
+	if err != nil {
+		panic(err)
+	}
 	f.Close()
 
 	fmt.Printf("Wrote index file: %s\n", f.Name())
 
 }
 
-
 // A more extensive test - index the complete works of William Shakespeare
 func NoTestTheBardIndexing(t *testing.T) {
-	
+
 	fmt.Println("TestTheBardIndexing")
 
-	idx, err := NewIndexer(""); if err != nil { panic(err) }
+	idx, err := NewIndexer()
+	if err != nil {
+		panic(err)
+	}
 	defer idx.Close()
 
 	titlere := re.MustCompile("(?i)<title>([^<]+)</title>")
@@ -46,11 +57,14 @@ func NoTestTheBardIndexing(t *testing.T) {
 		if !f.IsDir() /*&& n < 5*/ {
 			n++
 			fmt.Printf("indexing: %s\n", path)
-			b, err := ioutil.ReadFile(path); if err != nil { panic(err) }
+			b, err := ioutil.ReadFile(path)
+			if err != nil {
+				panic(err)
+			}
 			title := string(titlere.Find(b))
 			body := HTMLStripTags(string(b))
 			doc := IndexDoc{
-				Id: []byte(path),
+				Id:         []byte(path),
 				StoreValue: []byte(title),
 				IndexValue: []byte(title + " " + title + " " + body),
 			}
@@ -59,15 +73,17 @@ func NoTestTheBardIndexing(t *testing.T) {
 		return nil
 	})
 
-	// idx.DebugDump(os.Stdout)
-
 	fmt.Println("Writing final index...")
-	f, err := ioutil.TempFile("", "idxout"); if err != nil { panic(err) }
-	err = idx.FinalizeAndWrite(f); if err != nil { panic(err) }
+	f, err := ioutil.TempFile("", "idxout")
+	if err != nil {
+		panic(err)
+	}
+	err = idx.FinalizeAndWrite(f)
+	if err != nil {
+		panic(err)
+	}
 	f.Close()
 
 	fmt.Printf("Wrote index file: %s\n", f.Name())
 
 }
-
-

--- a/searcher.go
+++ b/searcher.go
@@ -1,82 +1,80 @@
 package fulltext
 
 import (
-	"os"
-	"fmt"
+	"encoding/gob"
+	"github.com/jbarham/go-cdb"
+	"github.com/spf13/afero"
 	"io"
 	"io/ioutil"
 	"sort"
-	"encoding/gob"
-	"github.com/jbarham/go-cdb"
 )
 
 // Interface for search.  Not thread-safe, but low overhead
 // so having a separate one per thread should be workable.
 type Searcher struct {
-	file *os.File
-	docCdb *cdb.Cdb
+	file    afero.File
+	docCdb  *cdb.Cdb
 	wordCdb *cdb.Cdb
 }
 
 // Wraps a ReaderAt and adjusts (tweaks) it's offset by the specified amount
 type tweakedReaderAt struct {
 	readerAt io.ReaderAt
-	tweak int64
+	tweak    int64
 }
-func (t *tweakedReaderAt)ReadAt(p []byte, off int64) (n int, err error) {
-	n, err = t.readerAt.ReadAt(p, off+t.tweak); return
+
+func (t *tweakedReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
+	n, err = t.readerAt.ReadAt(p, off+t.tweak)
+	return
 }
 
 // A single item in a search result
 type SearchResultItem struct {
-	Id []byte // id of this item (document)
+	Id         []byte // id of this item (document)
 	StoreValue []byte // the stored value of this document
-	Score int64 // the total score
+	Score      int64  // the total score
 }
-// Implement sort.Interface
-type SearchResultItems []SearchResultItem;
-func (s SearchResultItems) Len() int { return len(s) }
-func (s SearchResultItems) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s SearchResultItems) Less(i, j int) bool { return s[i].Score < s[j].Score }
 
+// Implement sort.Interface
+type SearchResultItems []SearchResultItem
+
+func (s SearchResultItems) Len() int           { return len(s) }
+func (s SearchResultItems) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s SearchResultItems) Less(i, j int) bool { return s[i].Score < s[j].Score }
 
 // What happened during the search
 type SearchResults struct {
 	Items SearchResultItems
 }
 
-
-// Make a new searcher using the file at the specified path
-// TODO: Make a variation that accepts a ReaderAt
-func NewSearcher(fpath string) (*Searcher, error) {
+// NewSearcher creates a new searcher instance from the given index file.
+func NewSearcher(indexFile afero.File) (*Searcher, error) {
 
 	s := &Searcher{}
 
-	f, err := os.Open(fpath); if err != nil { return s, err }
-	s.file = f
-
+	s.file = indexFile
 
 	// write out the word data
-	dec := gob.NewDecoder(f)
+	dec := gob.NewDecoder(indexFile)
 	lens := make([]int64, 2, 2)
 	dec.Decode(&lens)
 
-	s.docCdb = cdb.New(&tweakedReaderAt{f,HEADER_SIZE})
-	s.wordCdb = cdb.New(&tweakedReaderAt{f,HEADER_SIZE + lens[0]})
+	s.docCdb = cdb.New(&tweakedReaderAt{indexFile, HEADER_SIZE})
+	s.wordCdb = cdb.New(&tweakedReaderAt{indexFile, HEADER_SIZE + lens[0]})
 
 	return s, nil
 }
 
 // Close and release resources
-func (s *Searcher)Close() error {
+func (s *Searcher) Close() error {
 	s.docCdb = nil
 	s.wordCdb = nil
 	return s.file.Close()
-	fmt.Printf(""); return nil
+	return nil
 }
 
 // Perform a search
-func (s *Searcher)SimpleSearch(search string, maxn int) (SearchResults, error) {
+func (s *Searcher) SimpleSearch(search string, maxn int) (SearchResults, error) {
 
 	sr := SearchResults{}
 
@@ -89,13 +87,21 @@ func (s *Searcher)SimpleSearch(search string, maxn int) (SearchResults, error) {
 	for _, w := range searchWords {
 		w = IndexizeWord(w)
 		// find the docs for this word
-		mapGob, err := s.wordCdb.Find([]byte(w));
-		if err == io.EOF { continue }; if err != nil { return sr, err }
+		mapGob, err := s.wordCdb.Find([]byte(w))
+		if err == io.EOF {
+			continue
+		}
+		if err != nil {
+			return sr, err
+		}
 
 		m := make(map[string]int)
 
 		dec := gob.NewDecoder(mapGob)
-		err = dec.Decode(&m); if err != nil { return sr, err }
+		err = dec.Decode(&m)
+		if err != nil {
+			return sr, err
+		}
 
 		// for each doc, increase score
 		for docId, cnt := range m {
@@ -111,21 +117,32 @@ func (s *Searcher)SimpleSearch(search string, maxn int) (SearchResults, error) {
 
 	// convert to slice
 	items := make(SearchResultItems, 0, maxn)
-	for _, item := range itemMap { items = append(items, item) }
+	for _, item := range itemMap {
+		items = append(items, item)
+	}
 
 	// sort by score descending
 	sort.Sort(sort.Reverse(items))
 
 	// limit to maxn
-	if len(items) > maxn { items = items[:maxn] }
+	if len(items) > maxn {
+		items = items[:maxn]
+	}
 
 	// pull document contents from doc cdb
 	for i := range items {
 		item := &items[i]
-		v, err := s.docCdb.Find(item.Id);
-		if err == io.EOF { panic("doc id " + string(item.Id) + " not found in index, this should never happen") }
-		if err != nil { return sr, err }
-		v1, err := ioutil.ReadAll(v); if err != nil { return sr, err }
+		v, err := s.docCdb.Find(item.Id)
+		if err == io.EOF {
+			panic("doc id " + string(item.Id) + " not found in index, this should never happen")
+		}
+		if err != nil {
+			return sr, err
+		}
+		v1, err := ioutil.ReadAll(v)
+		if err != nil {
+			return sr, err
+		}
 		item.StoreValue = v1
 	}
 


### PR DESCRIPTION
Hej.
I am happily using your fulltext library for my [markdown webserver "allmark"](https://github.com/andreaskoch/allmark) and the only thing bothering me was that your library required files on disk which I had to clean up every time I created a new index. But then I recently stumbled upon [github.com/spf13/afero](https://github.com/spf13/afero) - a filesystem abstraction library.

With [afero](https://github.com/spf13/afero) we can spare us the effort of cleaning up the filesystem every time we create a new index and even the Searcher can use an in-memory index file if this is desired. And it's still compatible to the os.File type.

You can see how much filesystem cleanup code I could save using afero.File for your fulltext library in my last commit to allmark: https://github.com/andreaskoch/allmark/commit/98f7643178fddccc43719a0545b37232594c4b49

You don't have to merge this pull request. Especially since my editor messed up your formatting but I thought seeing [spf13/afero](https://github.com/spf13/afero) in action in your library might interest you.

Greetings.
